### PR TITLE
Minor bug fixes

### DIFF
--- a/ros2_monocular_depth/ros2_monocular_depth/helper.py
+++ b/ros2_monocular_depth/ros2_monocular_depth/helper.py
@@ -46,7 +46,7 @@ class TRTMiDaS(Node):
         self.weight_path = os.path.join(self.model_dir, 'model_small.pt')
 
     def start(self):
-        if not TRT_OUTPUT_MODEL_PATH:
+        if not os.path.isfile(self.trt_output_model_path):
             self.get_logger().info("Converting MiDaS Model to TensorRT")
             convert_midas(model_path=self.weight_path, trt_model_path=self.trt_output_model_path, in_width=256, in_height=256)
         self.get_logger().info("Loading MiDaS TensorRT model ")

--- a/ros2_monocular_depth/ros2_monocular_depth/helper.py
+++ b/ros2_monocular_depth/ros2_monocular_depth/helper.py
@@ -66,7 +66,7 @@ class TRTMiDaS(Node):
     def read_cam_callback(self, msg):
         img = np.asarray(msg.data)
         self.image = np.reshape(img, (msg.height, msg.width, 3))
-        self.get_logger().info("Executing MiDaS: depth estimation using TensorRT (torch2trt)...\n"
+        self.get_logger().info("Executing MiDaS: depth estimation using TensorRT (torch2trt)...\n")
 
         cv2.imshow("Input Image", self.image)
         self.depth_image = self.execute()

--- a/ros2_monocular_depth/ros2_monocular_depth/utils.py
+++ b/ros2_monocular_depth/ros2_monocular_depth/utils.py
@@ -29,11 +29,11 @@ from torch2trt import torch2trt, trt
 from torch2trt import TRTModule
 import PIL
 
-from midas.midas_net_custom import MidasNet_small
+from .MiDaS.midas.midas_net_custom import MidasNet_small
 from torchvision.transforms import Compose
-from midas.midas_net import MidasNet
-from midas.midas_net_custom import MidasNet_small
-from midas.transforms import Resize, NormalizeImage, PrepareForNet
+from .MiDaS.midas.midas_net import MidasNet
+from .MiDaS.midas.midas_net_custom import MidasNet_small
+from .MiDaS.midas.transforms import Resize, NormalizeImage, PrepareForNet
 
 
 def convert_midas(model_path, trt_model_path, in_width, in_height):

--- a/ros2_monocular_depth/setup.py
+++ b/ros2_monocular_depth/setup.py
@@ -5,7 +5,7 @@ package_name = 'ros2_monocular_depth'
 setup(
     name=package_name,
     version='0.0.0',
-    packages=[package_name],
+    packages=[package_name,package_name + '/MiDaS'],
     data_files=[
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),


### PR DESCRIPTION
- Closed parenthesis before `cv2.imshow()`
- Added MiDaS as a submodule to setup.py given that it's been cloned as stated in the README.
- Changed the MiDaS imports in utils according to the last point.
- Finaly swapped out `if not TRT_OUTPUT_MODEL_PATH:` with `if not os.path.isfile(self.trt_output_model_path):` to check whether a serialized engine exists already.

Everything hums along wonderfully after adding these!